### PR TITLE
Cassandra playbook and cassandra ansible host setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ override.tf.json
 .DS_Store
 terraform/.terraform.lock.hcl
 terraform/assets/secrets/*
+.vscode/settings.json

--- a/ansible/apache_server-setup.yaml
+++ b/ansible/apache_server-setup.yaml
@@ -1,6 +1,6 @@
 ---
 - hosts: localhost
-  become: yes
+  become: true
   tasks: 
     - name: Install Apache
       package:

--- a/ansible/apache_server-setup.yaml
+++ b/ansible/apache_server-setup.yaml
@@ -4,8 +4,8 @@
   tasks:
     - name: Update and upgrade apt packages
       apt:
-      upgrade: yes
-      update_cache: yes
+        upgrade: yes
+        update_cache: yes
     - name: Install Apache
       package:
         name: apache2

--- a/ansible/apache_server-setup.yaml
+++ b/ansible/apache_server-setup.yaml
@@ -1,7 +1,11 @@
 ---
 - hosts: localhost
   become: true
-  tasks: 
+  tasks:
+    - name: Update and upgrade apt packages
+      apt:
+      upgrade: yes
+      update_cache: yes
     - name: Install Apache
       package:
         name: apache2

--- a/ansible/cassandra_node-setup.yaml
+++ b/ansible/cassandra_node-setup.yaml
@@ -1,0 +1,33 @@
+---
+- hosts:
+    - cassandra_nodes
+  become: true
+  tasks: 
+    - name: Install MC
+      package:
+        name: mc
+        state: latest
+    - name: Install openjdk-11-jre-headless
+      service:
+         name: openjdk-11-jre-headless
+         state: present
+    - name: Install apt-transport-https
+      package:
+        name: apt-transport-https
+        state: present
+    - name: Add cassandra debian repository
+      apt_repository: repo='deb http://www.apache.org/dist/cassandra/debian 40x main'
+      state: present
+    - name: Add the key for the cassandra debian repo
+      apt_key: keyserver=pgp.mit.edu id=F758CE318D77295D
+
+    - name: Add another key for cassandra
+      apt_key: keyserver=pgp.mit.edu id=2B5C1B00
+
+    - name: Install cassandra
+      package:
+        name: cassandra
+        state: present
+
+    - name: make sure cassandra is started
+      service: name=cassandra state=restarted

--- a/ansible/cassandra_node-setup.yaml
+++ b/ansible/cassandra_node-setup.yaml
@@ -5,8 +5,8 @@
   tasks: 
     - name: Update and upgrade apt packages
       apt:
-      upgrade: yes
-      update_cache: yes
+        upgrade: yes
+        update_cache: yes
     - name: Install MC
       package:
         name: mc

--- a/ansible/cassandra_node-setup.yaml
+++ b/ansible/cassandra_node-setup.yaml
@@ -2,7 +2,7 @@
 - hosts:
     - cassandra_nodes
   become: true
-  tasks: 
+  tasks:
     - name: Update and upgrade apt packages
       apt:
         upgrade: yes
@@ -11,21 +11,24 @@
       package:
         name: mc
         state: latest
+
     - name: Install openjdk-11-jre-headless
-      service:
+      package:
          name: openjdk-11-jre-headless
          state: present
+
     - name: Install apt-transport-https
       package:
         name: apt-transport-https
         state: present
-    - name: Add cassandra debian repository
-      apt_repository: repo='deb http://www.apache.org/dist/cassandra/debian 40x main'
-    - name: Add the key for the cassandra debian repo
-      apt_key: keyserver=pgp.mit.edu id=F758CE318D77295D
 
     - name: Add another key for cassandra
-      apt_key: keyserver=pgp.mit.edu id=2B5C1B00
+      apt_key:
+        url: https://www.apache.org/dist/cassandra/KEYS
+        state: present
+
+    - name: Add cassandra debian repository
+      apt_repository: repo='deb http://www.apache.org/dist/cassandra/debian 40x main'
 
     - name: Install cassandra
       package:

--- a/ansible/cassandra_node-setup.yaml
+++ b/ansible/cassandra_node-setup.yaml
@@ -3,6 +3,10 @@
     - cassandra_nodes
   become: true
   tasks: 
+    - name: Update and upgrade apt packages
+      apt:
+      upgrade: yes
+      update_cache: yes
     - name: Install MC
       package:
         name: mc

--- a/ansible/cassandra_node-setup.yaml
+++ b/ansible/cassandra_node-setup.yaml
@@ -21,7 +21,6 @@
         state: present
     - name: Add cassandra debian repository
       apt_repository: repo='deb http://www.apache.org/dist/cassandra/debian 40x main'
-      state: present
     - name: Add the key for the cassandra debian repo
       apt_key: keyserver=pgp.mit.edu id=F758CE318D77295D
 

--- a/terraform/assets/templates/hosts.tpl
+++ b/terraform/assets/templates/hosts.tpl
@@ -1,0 +1,9 @@
+[cassandra_nodes]
+${cassandra_node1}
+${cassandra_node2}
+
+[canssandra_main_node]
+${cassandra_node1}
+
+[canssandra_secondary_node]
+${cassandra_node2}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -16,6 +16,8 @@ module "apache-ec2"{
     subnet_id = module.devops_db_group-vpc.public_subnets_id[0]
     aws_private_key = var.aws-private-key-location
     aws-keypair-name = var.aws-access-key-name
+    apache-ec2-depends_on = [module.cassandra-ec2.inventorycreate]
+
 }
 
 module "cassandra-ec2"{

--- a/terraform/modules/ec2/apache/main.tf
+++ b/terraform/modules/ec2/apache/main.tf
@@ -56,7 +56,7 @@ provisioner "remote-exec" {
     inline = [
       "sudo chmod 400 ~/.ssh/id_rsa",
       "sudo apt-add-repository ppa:ansible/ansible -y",
-      "sudo apt update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade",
+      "sudo apt update -y",
       "sudo apt install ansible -y",
       "sudo mv /etc/ansible/hosts /etc/ansible/hosts.bak",
       "sudo mv /tmp/hosts /etc/ansible/hosts",

--- a/terraform/modules/ec2/apache/variables.tf
+++ b/terraform/modules/ec2/apache/variables.tf
@@ -35,3 +35,7 @@ variable "aws_private_key"{
 variable "aws-keypair-name"{
     description = "AWS key pair name used for connecting to instances"
 }
+
+variable "apache-ec2-depends_on" {
+    description = "Apache Ec2 dependancy"
+}

--- a/terraform/modules/ec2/cassandra/main.tf
+++ b/terraform/modules/ec2/cassandra/main.tf
@@ -28,8 +28,7 @@ resource "aws_instance" "cassandra_db_node_1" {
   }
   provisioner "remote-exec" {
     inline = [
-      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys",
-      "sudo apt update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade"
+      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys"
     ]
 
   connection {
@@ -52,7 +51,7 @@ resource "aws_instance" "cassandra_db_node_2" {
   }
   provisioner "remote-exec" {
     inline = [
-      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys",
+      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys"
     ]
 
   connection {

--- a/terraform/modules/ec2/cassandra/main.tf
+++ b/terraform/modules/ec2/cassandra/main.tf
@@ -26,6 +26,19 @@ resource "aws_instance" "cassandra_db_node_1" {
   tags = {
     Name = "cassandra_db_node_1"
   }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys",
+      "sudo apt update -y && sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade"
+    ]
+
+  connection {
+      type        = "ssh"
+      user        = "ubuntu"
+      private_key = file("${var.aws_private_key}")
+      host        = self.public_dns
+    }
+  }
 }
 
 resource "aws_instance" "cassandra_db_node_2" {
@@ -37,4 +50,26 @@ resource "aws_instance" "cassandra_db_node_2" {
   tags = {
     Name = "cassandra_db_node_2"
   }
+  provisioner "remote-exec" {
+    inline = [
+      "sudo echo \"${file("./assets/secrets/public-key.pub")}\" >> .ssh/authorized_keys",
+    ]
+
+  connection {
+      type        = "ssh"
+      user        = "ubuntu"
+      private_key = file("${var.aws_private_key}")
+      host        = self.public_dns
+    }
+  }
+}
+
+resource "local_file" "hosts_cfg" {
+  content = templatefile("./assets/templates/hosts.tpl",
+    {
+      cassandra_node1 = aws_instance.cassandra_db_node_1.public_dns
+      cassandra_node2 = aws_instance.cassandra_db_node_2.public_dns
+    }
+  )
+  filename = "./assets/inventory/hosts.cfg"
 }

--- a/terraform/modules/ec2/cassandra/output.tf
+++ b/terraform/modules/ec2/cassandra/output.tf
@@ -17,3 +17,10 @@ output "cassandra_db_node_2_instance_public_ip" {
   description = "Public IP address of the EC2 cassandra_db_node_2 instance"
   value       = aws_instance.cassandra_db_node_2.public_ip
 }
+
+output "inventorycreate" {
+  value={}
+  depends_on = [
+    local_file.hosts_cfg
+  ]
+}


### PR DESCRIPTION
• Created a playbook for installing cassandra on cassandra nodes
• Fixed typos in apache playbook and moved apt management to playbook
• Created a template for automatic cassandra instance dns name propogation in ansible inventory
• Added dependency on inventory file to avoid terraform errors
• Deployed ansible master public ssh key to ansible hosts authorized keys